### PR TITLE
Using links wrapper to set correct ip-address for mongodb

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 
 var express = require('express');
 var ParseServer = require('parse-server').ParseServer;
+var links = require('docker-links').parseLinks(process.env);
 
 var databaseUri = process.env.DATABASE_URI || process.env.MONGOLAB_URI
 
@@ -24,7 +25,7 @@ if (process.env.PARSE_SERVER_OPTIONS) {
 */
 
 var api = new ParseServer({
-  databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
+  databaseURI: databaseUri || 'mongodb://' + links.mongo.hostname + ':27017/dev',
   cloud: process.env.CLOUD_CODE_MAIN || __dirname + '/cloud/main.js',
 
   appId: process.env.APP_ID || 'myAppId',

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "docker-links": "^1.0.2",
     "express": "~4.2.x",
     "kerberos": "~0.0.x",
     "parse": "~1.6.12",


### PR DESCRIPTION
With docker-machine (using docker on mac/win), a linked docker is not available on 172.0.0.1 so we need to get the right host by parsing environment variables.