### PR TITLE
allow usage of express' 'trust proxy' to use reverse proxy for parse …

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,8 @@ parse-server:
     ALLOW_CLIENT_CLASS_CREATION: $ALLOW_CLIENT_CLASS_CREATION # true
     APP_NAME: $APP_NAME
     PUBLIC_SERVER_URL: $PUBLIC_SERVER_URL
-# ...
+    TRUST_PROXY: $TRUST_PROXY # false
+# ... 
 ```
 
 Remote parse-cloud-code image:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,8 @@ parse-server:
     ALLOW_CLIENT_CLASS_CREATION: $ALLOW_CLIENT_CLASS_CREATION # true
     APP_NAME: $APP_NAME
     PUBLIC_SERVER_URL: $PUBLIC_SERVER_URL
-  links:
+    TRUST_PROXY: $TRUST_PROXY 
+ links:
     - mongo
   volumes_from:
     - parse-cloud-code

--- a/index.js
+++ b/index.js
@@ -90,6 +90,11 @@ var api = new ParseServer({
 
 var app = express();
 
+if(process.env.TRUST_PROXY == 1) {
+  console.log("trusting proxy");
+  app.enable('trust proxy');
+}
+
 // Serve the Parse API on the /parse URL prefix
 var mountPath = process.env.PARSE_MOUNT || '/parse';
 app.use(mountPath, api);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "nodemon": "^1.8.1",
     "docker-links": "^1.0.2",
-    "express": "~4.2.x",
+    "express": "~4.13.x",
     "kerberos": "~0.0.x",
     "parse": "~1.6.12",
     "parse-server": "~2.1.4"


### PR DESCRIPTION
…server, increased minimum required express version

We are using this for a reverse proxy with nginx and need to use the `X-Forwarded-Proto` and `X-Forwarded-Host` as described in https://github.com/ParsePlatform/parse-server/issues/905
This PR implements it.