### PR TITLE
Bump to 2.3.1 with updated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@
 [![Screencast](https://github.com/yongjhih/docker-parse-server/raw/master/art/docker-parse-server.gif)](https://youtu.be/1bYWSPEZL2g)
 
 ## :rocket: Deployments
+
+> #### Note
+* If you are upgrading from version below 2.3.0, please see [these recommended steps](https://github.com/ParsePlatform/parse-server/blob/master/2.3.0.md).
+
 ### :paperclip: Deploy with Docker
 ```sh
 $ docker run -d -p 27017:27017 --name mongo mongo

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -21,7 +21,7 @@ generate-version() {
 
 echo '# maintainer: Andrew Chen <yongjhih@gmail.com> (@yongjhih)'
 
-versions=( 2.0.{0..8} 2.1.{0..6} 2.2.{0..7} master )
+versions=( 2.0.{0..8} 2.1.{0..6} 2.2.{0..22} 2.3.{0..1}  master )
 
 for version in "${versions[@]}"; do
 	generate-version "$version"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-parse-server",
-  "version": "2.2.22",
+  "version": "2.3.1",
   "description": "Parse Server as docker container",
   "main": "index.js",
   "repository": {
@@ -10,14 +10,14 @@
   "license": "MIT",
   "dependencies": {
     "docker-links": "^1.0.2",
-    "express": "~4.11.x",
+    "express": "~4.14.x",
     "express-graphql": "^0.6.1",
     "graphql": "^0.8.2",
     "kerberos": "~0.0.x",
-    "mongodb": "2.1.18",
-    "nodemon": "^1.8.1",
-    "parse": "~1.8.0",
-    "parse-server": "2.2.22",
+    "mongodb": "2.2.10",
+    "nodemon": "^1.11.0",
+    "parse": "~1.9.2",
+    "parse-server": "2.3.1",
     "parse-server-azure-storage": "^1.1.0"
   },
   "scripts": {

--- a/tag
+++ b/tag
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-for i in 2.2.{0..22}; do
+for i in 2.3.{0..1}; do
   sed -i 's/"parse-server": "[^"]\+"/"parse-server": "'"$i"'"/' package.json
   git commit -am "Bump to $i"
   git tag -f "$i"
 done
 
-echo git push origin 2.2.{0..22}
+echo git push origin 2.3.{0..1}


### PR DESCRIPTION
Update parse-server to 2.3.1

Other dependencies updated:
* express from 4.11 to 4.14
* mongodb from 2.1.18 to 2.2.10
* nodemon from 1.8.1 to 1.11.0
* parse from 1.8.0 to 1.9.2

Fixes https://github.com/yongjhih/docker-parse-server/issues/78