### PR TITLE
Add log level configuration

### DIFF
--- a/ADVANCE.md
+++ b/ADVANCE.md
@@ -189,6 +189,7 @@ docker-compose up
 * Specify parse cloud code host folder: `-v {/home/yongjhih/parse/cloud}:/parse/cloud`
 * Specify parse cloud code volume container: `--volumes-from {parse-cloud-code}`
 * Specify parse-server prefix: `-e PARSE_MOUNT={/parse}`
+* Specify parse-server log level: `-e LOG_LEVEL={info}`
 
 ## How to config Docker Compose
 
@@ -231,6 +232,7 @@ parse-server:
     APP_NAME: $APP_NAME
     PUBLIC_SERVER_URL: $PUBLIC_SERVER_URL
     TRUST_PROXY: $TRUST_PROXY # false
+    LOG_LEVEL: $LOG_LEVEL # info
 # ...
 ```
 

--- a/docker-compose-le.yml
+++ b/docker-compose-le.yml
@@ -65,6 +65,7 @@ parse-server:
     LETSENCRYPT_EMAIL: $PARSE_SERVER_LETSENCRYPT_EMAIL
     GRAPHQL_SUPPORT:  $GRAPHQL_SUPPORT
     GRAPHQL_SCHEMA:   $GRAPHQL_SCHEMA
+    LOG_LEVEL:        $LOG_LEVEL
   links:
     - mongo
   volumes_from:

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -62,6 +62,7 @@ parse-server:
     AZURE_DIRECT:     $AZURE_DIRECT
     GRAPHQL_SUPPORT:  $GRAPHQL_SUPPORT
     GRAPHQL_SCHEMA:   $GRAPHQL_SCHEMA
+    LOG_LEVEL:        $LOG_LEVEL
   links:
     - mongo
   volumes_from:

--- a/docker-compose-without-dashboard.yml
+++ b/docker-compose-without-dashboard.yml
@@ -61,6 +61,7 @@ parse-server:
     AZURE_DIRECT:     $AZURE_DIRECT
     GRAPHQL_SUPPORT:  $GRAPHQL_SUPPORT
     GRAPHQL_SCHEMA:   $GRAPHQL_SCHEMA
+    LOG_LEVEL:        $LOG_LEVEL
   links:
     - mongo
   volumes_from:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ parse-server:
     LIVEQUERY_CLASSES: $LIVEQUERY_CLASSES
     GRAPHQL_SUPPORT:  $GRAPHQL_SUPPORT
     GRAPHQL_SCHEMA:   $GRAPHQL_SCHEMA
+    LOG_LEVEL:        $LOG_LEVEL
   links:
     - mongo
   volumes_from:

--- a/index.js
+++ b/index.js
@@ -250,7 +250,8 @@ var api = new ParseServer({
     //oauth = {},
     appName: process.env.APP_NAME,
     publicServerURL: process.env.PUBLIC_SERVER_URL,
-    liveQuery: liveQueryParam
+    liveQuery: liveQueryParam,
+    logLevel: process.env.LOG_LEVEL || 'info'
     //customPages: process.env.CUSTOM_PAGES || // {
     //invalidLink: undefined,
     //verifyEmailSuccess: undefined,


### PR DESCRIPTION
It adds another (optional) environment variables: `LOG_LEVEL` to define parse-server log level.

Related to https://github.com/yongjhih/docker-parse-server/issues/80